### PR TITLE
reset counter upon creating iterator in MetaDataset.__iter__

### DIFF
--- a/jax_meta/datasets/base.py
+++ b/jax_meta/datasets/base.py
@@ -97,6 +97,7 @@ class MetaDataset(ABC):
 
     def __iter__(self):
         shape = self.data.shape[1:]
+        self.num_samples = 0
 
         while (self.size is None) or (self.num_samples < self.size):
             class_indices, indices, targets = self.get_indices()

--- a/jax_meta/metalearners/imaml.py
+++ b/jax_meta/metalearners/imaml.py
@@ -49,7 +49,7 @@ class iMAML(MAML):
 
         def _hvp_damping(tangents):
             damping = lambda h, t: (1. + self.regu_coef) * t + h / (self.lambda_ + self.cg_damping)
-            return tree_util.tree_multimap(damping, hvp_fn(tangents), tangents)
+            return tree_util.tree_map(damping, hvp_fn(tangents), tangents)
 
         return _hvp_damping
 
@@ -91,6 +91,5 @@ class iMAML(MAML):
         updates, opt_state = self.optimizer.update(grads, state.optimizer, params)
         params = optax.apply_updates(params, updates)
 
-        state = MetaLearnerState(model=model_state, optimizer=opt_state)
-
+        state = MetaLearnerState(model=model_state, optimizer=opt_state, key=state.key)
         return params, state, logs


### PR DESCRIPTION
Hey Tristan,
I found that the current behaviour of `datasets.MetaDataset.__iter__` might be a bit counter-intuitive as after consuming the iterator once, creating another iterator without calling `datasets.MetaDataset.reset` first will yield an empty iterator. Is this deliberate? The alternative of always providing an iterator over the full dataset upon calling `__iter__` would require only a minimal change of the code but feel free to delete this merge request in case the current behaviour is intended.

Simon